### PR TITLE
Add support for pagination with Koa.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mongoose Optimized Paginate (MOP)
-Optimized pagination using indexes (no cursor.skip) with fallback. Used with Mongoose + Express.
+Optimized pagination using indexes (no cursor.skip) with fallback. Used with Mongoose + Express, or Mongoose + Koa.
 
 ### Getting Started
 ```sh
@@ -17,7 +17,7 @@ mongoose.plugin(mongoosePlugin);
 
 Now you can start paginating!
 
-### Examples
+### Express Examples
 ```js
 var mongoose = require('mongoose'),
 	// returns a function(model, [config])
@@ -54,7 +54,97 @@ app.get('/courses', function(req, res, next) {
 		res.json(results);
 	});
 });
+
+app.get('/other-courses', function(req, res, next) {
+	var options = {};
+	model.paginate(
+		req.query.search,
+		req.query.currentPage,
+		req.query.page,
+		req.query.pageSize,
+		options
+	)
+	.then(function(pagingData) {
+		/* pagingData = {
+			newCurrentPage: 1,
+			"before": "<encoded>",
+			"after": "<encoded>",
+			"pageCount": 10,
+			"numPages": 10,
+			"total": 100,
+			"items": [{<courses}]
+		}; */
+
+		res.json(pagingData);
+	});
+});
 ```
+
+### Koa Examples
+```js
+var mongoose = require('mongoose'),
+	// returns a function(model, [config])
+	paginate = require('mongoose-opt-paginate').koa;
+
+// assuming a course model exists
+var model = mongoose.model('Course');
+
+// returns a function(ctx, search, options, cb)
+paginate = paginate(model);
+
+router.get('/courses', function* () {
+	var ctx = this;
+	// no callback will assume end of route (ctx.body called with results)
+	paginate(ctx, {}, {});
+	// with callback
+	paginate(ctx, {}, {}, function(results) {
+		/* results = {
+			"page": 1,
+			"hasMore": true,
+			"links": {
+				"first": "/courses?page=1&currentPage=1&pageSize=10",
+				"next": "/courses?page=2&currentPage=1&pageSize=10&after=<encoded>",
+				"last": "/courses?page=2&currentPage=1&pageSize=10&last=true"
+			},
+			"pageCount": 10,
+			"total": 14,
+			"before": "<encoded>",
+			"after": "<encoded>",
+			"data": [{<courses>}]
+		} */
+
+		// do something with results
+
+		ctx.body = results;
+	});
+});
+
+app.get('/other-courses', function* () {
+	var ctx = this;
+	var options = {};
+	model.paginate(
+		req.query.search,
+		req.query.currentPage,
+		req.query.page,
+		req.query.pageSize,
+		options
+	)
+	.then(function(pagingData) {
+		/* pagingData = {
+			newCurrentPage: 1,
+			"before": "<encoded>",
+			"after": "<encoded>",
+			"pageCount": 10,
+			"numPages": 10,
+			"total": 100,
+			"items": [{<courses}]
+		}; */
+
+		ctx.body = pagingData;
+	});
+});
+```
+
 #### Things to Note
 
 `before` and `after` are encoded strings containing the necessary item information of the first and last item of the returned results for optimized pagination. If sorting, make sure a compound index (collection-level) exists for the sort field(s) and _id field in proper order
@@ -72,6 +162,10 @@ Looking to contribute? Awesome! Make sure you've got [EditorConfig](http://edito
 - Documentation
 
 ### Release History
+#### 1.0.0
+- Added support for koa pagination
+- The mongoose plugin now uses promises rather than callbacks
+
 #### 0.3.0
 - Added some unit tests to mongoosePaginateSpec.js.
 - Can now provide both options.before and options.after. The library handles the logic of which to use.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - sudo /etc/init.d/mongodb stop
+    - sudo pip install --upgrade docker-compose==1.5.2
+    - docker-compose pull
+    - docker-compose up -d
+  cache_directories:
+    - node_modules
+
+test:
+  pre:
+    - npm view mongoose-opt-paginate
+    - npm start
+  override:
+    - npm run ci
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+mongo:
+  image: mongo:3.0.9
+  net: "host"
+  volumes:
+  - ~/db:/data/db

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
 	api: require('./lib/pagination'),
-	plugin: require('./lib/mongoosePaginate')
+	plugin: require('./lib/mongoosePaginate'),
+	koa: require('./koa/pagination')
 };

--- a/koa/pagination.js
+++ b/koa/pagination.js
@@ -1,0 +1,124 @@
+var	paginationHelpers = require('../lib/paginationHelpers');
+
+module.exports = function(Model, conf) {
+	if (!conf) {
+		conf = {
+			defaultPageSize: 10,
+			maxPageSize: 50
+		};
+	} else {
+		conf.defaultPageSize = conf.defaultPageSize ? conf.defaultPageSize : 10;
+		conf.maxPageSize = conf.maxPageSize ? conf.maxPageSize : 50;
+	}
+
+	function formatResponse(ctx, currentPage, before, after, pageCount, numPages, total, items) {
+		if (before) {
+			ctx.query.before = before;
+		}
+
+		if (after) {
+			ctx.query.after = after;
+		}
+
+		ctx.query.currentPage = currentPage;
+
+		var response = {
+			page: currentPage,
+			hasMore: paginationHelpers.hasNextPages(ctx.query)(numPages),
+			links: {
+				first: paginationHelpers.firstPage(ctx.request, ctx.query),
+				prev: paginationHelpers.prevPage(ctx.request, ctx.query, numPages),
+				next: paginationHelpers.nextPage(ctx.request, ctx.query, numPages),
+				last: paginationHelpers.lastPage(ctx.request, ctx.query, numPages)
+			},
+			pageCount: pageCount,
+			total: total,
+			before: before,
+			after: after,
+			data: items
+		};
+
+		return response;
+	}
+
+	function searchModelAndPaginate(ctx, search, options, cb) {
+		return Model.paginate(
+			search,
+			ctx.query.currentPage,
+			ctx.query.page,
+			ctx.query.pageSize,
+			options
+		)
+		.then(function(pagingData) {
+			if (typeof cb === 'function') {
+				cb(null, formatResponse(
+					ctx,
+					pagingData.newCurrentPage,
+					pagingData.before,
+					pagingData.after,
+					pagingData.pageCount,
+					pagingData.numPages,
+					pagingData.total,
+					pagingData.items
+				));
+			} else {
+				return formatResponse(
+					ctx,
+					pagingData.newCurrentPage,
+					pagingData.before,
+					pagingData.after,
+					pagingData.pageCount,
+					pagingData.numPages,
+					pagingData.total,
+					pagingData.items
+				);
+			}
+		}, function(err) {
+			if (typeof cb === 'function') {
+				cb(err, null);
+				return;
+			}
+
+			throw err;
+		});
+	}
+
+	return function paginate(ctx, search, options, cb) {
+		paginationHelpers.setQueryParams(ctx.query, conf.defaultPageSize, conf.maxPageSize);
+
+		options = options || {};
+
+		if (ctx.query.sortBy) {
+			options.sortBy = {};
+
+			var splitFields = ctx.query.sortBy.split(',');
+
+			var ascendingSortDirection = '1';
+			var directions = ctx.query.sortDirection || ascendingSortDirection;
+			var splitDirections = directions.split(',');
+
+			for(var i = 0; splitFields[i]; i++) {
+				splitFields[i] = splitFields[i].trim();
+				options.sortBy[splitFields[i]] = splitDirections[i] || 1;
+			}
+		}
+
+		if (ctx.query.before) {
+			options.before = ctx.query.before;
+		}
+
+		if (ctx.query.after) {
+			options.after = ctx.query.after;
+		}
+
+		if (ctx.query.last) {
+			options.last = ctx.query.last;
+		}
+
+		if (!search) {
+			search = {};
+		}
+
+		return searchModelAndPaginate(ctx, search, options, cb);
+	};
+};

--- a/lib/mongoosePaginate.js
+++ b/lib/mongoosePaginate.js
@@ -79,46 +79,43 @@ function flipDirections(options) {
 	options.flip = !options.flip;
 }
 
-function execPagination(q, callback) {
+function execPagination(q) {
 	var _return = {},
 		after, before;
 
-	q.exec(function(err, objects) {
-		if (err) {
-			return callback(err);
-		}
+	return q.exec()
+		.then(function(objects) {
+			if (!objects) {
+				objects = [];
+			}
+			if (q.options.flip) {
+				objects.reverse();
+			}
 
-		if (!objects) {
-			objects = [];
-		}
-		if (q.options.flip) {
-			objects.reverse();
-		}
+			_return.objects = objects;
+			_return.thisPageCount = objects.length;
 
-		_return.objects = objects;
-		_return.thisPageCount = objects.length;
+			if (objects.length > 0) {
+				_return.after = {};
+				_return.before = {};
 
-		if (objects.length > 0) {
-			_return.after = {};
-			_return.before = {};
+				after = objects.length - 1;
+				before = 0;
 
-			after = objects.length - 1;
-			before = 0;
+				_.forEach(q.options.sortBy, function(direction, sortKey) {
+					_return.after[sortKey] = objects[after][sortKey].toString();
+					_return.before[sortKey] = objects[before][sortKey].toString();
+				});
 
-			_.forEach(q.options.sortBy, function(direction, sortKey) {
-				_return.after[sortKey] = objects[after][sortKey].toString();
-				_return.before[sortKey] = objects[before][sortKey].toString();
-			});
+				_return.after = encode(_return.after);
+				_return.before = encode(_return.before);
+			} else {
+				_return.after = null;
+				_return.before = null;
+			}
 
-			_return.after = encode(_return.after);
-			_return.before = encode(_return.before);
-		} else {
-			_return.after = null;
-			_return.before = null;
-		}
-
-		return callback(null, _return);
-	});
+			return _return;
+		});
 }
 
 function setPaginateParams(options, model, last, difference) {
@@ -190,51 +187,49 @@ function setPaginateParams(options, model, last, difference) {
 	});
 }
 
-function paginate(q, fromPageNumber, toPageNumber, resultsPerPage, callback, options) {
+function paginate(q, fromPageNumber, toPageNumber, resultsPerPage, options) {
 	var query, skipTo, columns, sortBy, filter, populate, pageJump,
 		last = options.last == 'true', model = this;
 
 	options = options || {};
-	setPaginateParams(options, model, last, toPageNumber - fromPageNumber).then(function() {
+	return setPaginateParams(options, model, last, toPageNumber - fromPageNumber)
+		.then(function() {
 
-		columns = options.columns || null;
-		sortBy = options.sortBy || null;
-		filter = options.filter || null;
-		populate = options.populate || null;
-		callback = callback || function() {};
+			columns = options.columns || null;
+			sortBy = options.sortBy || null;
+			filter = options.filter || null;
+			populate = options.populate || null;
 
-		skipTo = (toPageNumber * resultsPerPage) - resultsPerPage;
-		pageJump = Math.abs(toPageNumber - fromPageNumber);
+			skipTo = (toPageNumber * resultsPerPage) - resultsPerPage;
+			pageJump = Math.abs(toPageNumber - fromPageNumber);
 
-		query = model.find(clone(q));
+			query = model.find(clone(q));
 
-		if (columns) {
-			query = query.select(columns);
-		}
-		if (filter) {
-			query.setOptions(filter);
-		}
-		if (sortBy) {
-			query = query.sort(sortBy);
-		}
-		if (populate) {
-			if (Array.isArray(populate)) {
-				populate.forEach(function(field) {
-					query = query.populate(field);
-				});
-			} else {
-				query = query.populate(populate);
+			if (columns) {
+				query = query.select(columns);
 			}
-		}
-
-		query.options.flip = options.flip;
-		query.options.sortBy = options.sortBy;
-
-		model.count(q, function(err, count) {
-			if (err) {
-				return callback(err);
+			if (filter) {
+				query.setOptions(filter);
+			}
+			if (sortBy) {
+				query = query.sort(sortBy);
+			}
+			if (populate) {
+				if (Array.isArray(populate)) {
+					populate.forEach(function(field) {
+						query = query.populate(field);
+					});
+				} else {
+					query = query.populate(populate);
+				}
 			}
 
+			query.options.flip = options.flip;
+			query.options.sortBy = options.sortBy;
+
+			return model.count(q).exec();
+		})
+		.then(function(count) {
 			if (last) {
 				if (count % resultsPerPage) {
 					query = query.limit(count % resultsPerPage);
@@ -254,16 +249,19 @@ function paginate(q, fromPageNumber, toPageNumber, resultsPerPage, callback, opt
 				query = query.limit(resultsPerPage);
 			}
 
-			execPagination(query, function(err, data) {
-				if (err) {
-					return callback(err);
-				}
-
-				callback(null, toPageNumber, data.before, data.after, data.thisPageCount,
-						Math.ceil(count / resultsPerPage) || 1, count, data.objects);
-			});
+			return execPagination(query)
+				.then(function(data) {
+					return {
+						newCurrentPage: toPageNumber,
+						before: data.before,
+						after: data.after,
+						pageCount: data.thisPageCount,
+						numPages: Math.ceil(count / resultsPerPage) || 1,
+						total: count,
+						items: data.objects
+					};
+				});
 		});
-	});
 }
 
 module.exports = function(schema) {

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -1,4 +1,4 @@
-var	expressPaginate = require('./expressPaginate');
+var	paginationHelpers = require('./paginationHelpers');
 
 module.exports = function(Model, conf) {
 	if (!conf) {
@@ -11,7 +11,7 @@ module.exports = function(Model, conf) {
 		conf.maxPageSize = conf.maxPageSize ? conf.maxPageSize : 50;
 	}
 
-	function formatResponse(req, res, currentPage, before, after, pageCount, numPages, total, items) {
+	function formatResponse(req, currentPage, before, after, pageCount, numPages, total, items) {
 		if (before) {
 			req.query.before = before;
 		}
@@ -24,12 +24,12 @@ module.exports = function(Model, conf) {
 
 		var response = {
 			page: currentPage,
-			hasMore: expressPaginate.hasNextPages(req)(numPages),
+			hasMore: paginationHelpers.hasNextPages(req.query)(numPages),
 			links: {
-				first: expressPaginate.firstPage(req),
-				prev: expressPaginate.prevPage(req, numPages),
-				next: expressPaginate.nextPage(req, numPages),
-				last: expressPaginate.lastPage(req, numPages)
+				first: paginationHelpers.firstPage(req, req.query),
+				prev: paginationHelpers.prevPage(req, req.query, numPages),
+				next: paginationHelpers.nextPage(req, req.query, numPages),
+				last: paginationHelpers.lastPage(req, req.query, numPages)
 			},
 			pageCount: pageCount,
 			total: total,
@@ -42,29 +42,42 @@ module.exports = function(Model, conf) {
 	}
 
 	function searchModelAndPaginate(search, options, req, res, next, cb) {
-		Model.paginate(
+		return Model.paginate(
 			search,
 			req.query.currentPage,
 			req.query.page,
 			req.query.pageSize,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					next(err);
-					return;
-				}
-
-				if (typeof cb === 'function') {
-					cb(formatResponse(req, res, newCurrentPage, before, after, pageCount, numPages, total, items));
-				} else {
-					return res.json(formatResponse(req, res, newCurrentPage, before, after, pageCount, numPages, total, items));
-				}
-			},
 			options
-		);
+		)
+		.then(function(pagingData) {
+			if (typeof cb === 'function') {
+				cb(formatResponse(
+					req,
+					pagingData.newCurrentPage,
+					pagingData.before,
+					pagingData.after,
+					pagingData.pageCount,
+					pagingData.numPages,
+					pagingData.total,
+					pagingData.items
+				));
+			} else {
+				return formatResponse(
+					req,
+					pagingData.newCurrentPage,
+					pagingData.before,
+					pagingData.after,
+					pagingData.pageCount,
+					pagingData.numPages,
+					pagingData.total,
+					pagingData.items
+				);
+			}
+		}, next);
 	}
 
-	function paginate(req, res, next, search, options, cb) {
-		expressPaginate.setQueryParams(req, conf.defaultPageSize, conf.maxPageSize);
+	return function paginate(req, res, next, search, options, cb) {
+		paginationHelpers.setQueryParams(req.query, conf.defaultPageSize, conf.maxPageSize);
 
 		options = options || {};
 
@@ -100,7 +113,5 @@ module.exports = function(Model, conf) {
 		}
 
 		return searchModelAndPaginate(search, options, req, res, next, cb);
-	}
-
-	return paginate;
+	};
 };

--- a/lib/paginationHelpers.js
+++ b/lib/paginationHelpers.js
@@ -10,36 +10,36 @@ function decode(encoded) {
 	return querystring.parse(new Buffer(querystring.unescape(encoded), 'base64').toString('utf8'));
 }
 
-exports.setQueryParams = function setQueryParams(req, defaultPageSize, maxPageSize) {
+exports.setQueryParams = function setQueryParams(queryParams, defaultPageSize, maxPageSize) {
 	defaultPageSize = (typeof defaultPageSize === 'number') ? defaultPageSize : 10;
 	maxPageSize = (typeof maxPageSize === 'number') ? maxPageSize : 50;
 
-	req.query.page = parseInt(req.query.page, 10) || 1;
-	req.query.currentPage = parseInt(req.query.currentPage, 10) || req.query.page;
-	req.query.pageSize = parseInt(req.query.pageSize, 10) || defaultPageSize;
+	queryParams.page = parseInt(queryParams.page, 10) || 1;
+	queryParams.currentPage = parseInt(queryParams.currentPage, 10) || queryParams.page;
+	queryParams.pageSize = parseInt(queryParams.pageSize, 10) || defaultPageSize;
 
-	if (req.query.pageSize > maxPageSize) {
-		req.query.pageSize = maxPageSize;
+	if (queryParams.pageSize > maxPageSize) {
+		queryParams.pageSize = maxPageSize;
 	}
 
-	if (req.query.page < 1) {
-		req.query.page = 1;
+	if (queryParams.page < 1) {
+		queryParams.page = 1;
 	}
 
-	if (req.query.currentPage < 1) {
-		req.query.currentPage = req.query.page;
+	if (queryParams.currentPage < 1) {
+		queryParams.currentPage = queryParams.page;
 	}
 
-	if (req.query.pageSize < 1) {
-		req.query.pageSize = 1;
+	if (queryParams.pageSize < 1) {
+		queryParams.pageSize = 1;
 	}
 
-	if (req.query.before) {
-		req.query.before = decode(req.query.before);
+	if (queryParams.before) {
+		queryParams.before = decode(queryParams.before);
 	}
 
-	if (req.query.after) {
-		req.query.after = decode(req.query.after);
+	if (queryParams.after) {
+		queryParams.after = decode(queryParams.after);
 	}
 };
 
@@ -69,26 +69,26 @@ exports.href = function href(req) {
 	};
 };
 
-exports.hasNextPages = function hasNextPages(req) {
+exports.hasNextPages = function hasNextPages(queryParams) {
 	return function(numPages) {
 		if (typeof numPages !== 'number' || numPages < 0) {
 			throw new HttpError(500, '`numPages` is not a number >= 0');
 		}
-		return req.query.page < numPages;
+		return queryParams.page < numPages;
 	};
 };
 
-exports.hasPreviousPages = function hasPreviousPages(req) {
+exports.hasPreviousPages = function hasPreviousPages(queryParams) {
 	return function(numPages) {
 		if (typeof numPages !== 'number' || numPages < 0) {
 			throw new HttpError(500, '`numPages` is not a number >= 0');
 		}
-		return req.query.page > 1 && req.query.page <= numPages;
+		return queryParams.page > 1 && queryParams.page <= numPages;
 	};
 };
 
-exports.firstPage = function firstPage(req) {
-	var query = clone(req.query);
+exports.firstPage = function firstPage(req, queryParams) {
+	var query = clone(queryParams);
 
 	query.page = 1;
 
@@ -97,16 +97,16 @@ exports.firstPage = function firstPage(req) {
 	return url.parse(req.originalUrl).pathname + '?' + querystring.stringify(query);
 };
 
-exports.prevPage = function prevPage(req, numPages) {
-	return exports.hasPreviousPages(req)(numPages) ? exports.href(req)(true) : undefined;
+exports.prevPage = function prevPage(req, queryParams, numPages) {
+	return exports.hasPreviousPages(queryParams)(numPages) ? exports.href(req)(true) : undefined;
 };
 
-exports.nextPage = function nextPage(req, numPages) {
-	return exports.hasNextPages(req)(numPages) ? exports.href(req)(false) : undefined;
+exports.nextPage = function nextPage(req, queryParams, numPages) {
+	return exports.hasNextPages(queryParams)(numPages) ? exports.href(req)(false) : undefined;
 };
 
-exports.lastPage = function lastPage(req, numPages) {
-	var query = clone(req.query);
+exports.lastPage = function lastPage(req, queryParams, numPages) {
+	var query = clone(queryParams);
 
 	query.page = numPages;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-opt-paginate",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "Optimized pagination using indexes (no cursor.skip) with fallback. Used with Mongoose + Express.",
   "main": "index.js",
   "dependencies": {
@@ -40,7 +40,9 @@
     "mongodb",
     "optimized",
     "range",
-    "index"
+    "index",
+    "express",
+    "koa"
   ],
   "author": "Matthew Tesfaldet <tesfaldet@hotmail.com> (http://mtesfaldet.net/)",
   "license": "MIT",

--- a/test/unit/mongoosePaginateSpec.js
+++ b/test/unit/mongoosePaginateSpec.js
@@ -10,196 +10,166 @@ describe('mongoosePaginate', function () {
 
 	var Course = require('../fixtures/models/course');
 
-	it('should return a paginated collection upon request', function(done) {
+	it('should return a paginated collection upon request', function() {
 		var currentPage = '1',
 			page = '2',
 			resultsPerPage = '10';
 
-		Course.paginate(
+		return Course.paginate(
 			{},
 			currentPage,
 			page,
 			resultsPerPage,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					done(err);
-					return;
-				}
-				newCurrentPage.should.equal('2');
-				before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
-				after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
-				pageCount.should.equal(4);
-				numPages.should.equal(2);
-				total.should.equal(14);
-				items.should.be.Array;
-				items.should.not.be.empty;
-				done();
-			},
 			{}
-		);
+		)
+		.then(function(pagingData) {
+			pagingData.newCurrentPage.should.equal('2');
+			pagingData.before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
+			pagingData.after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
+			pagingData.pageCount.should.equal(4);
+			pagingData.numPages.should.equal(2);
+			pagingData.total.should.equal(14);
+			pagingData.items.should.be.Array;
+			pagingData.items.should.not.be.empty;
+		});
 	});
 
-	it('should return a paginated collection consisting of _id and specified columns', function(done) {
+	it('should return a paginated collection consisting of _id and specified columns', function() {
 		var currentPage = '1',
 			page = '2',
 			resultsPerPage = '10';
 
-		Course.paginate(
+		return Course.paginate(
 			{},
 			currentPage,
 			page,
 			resultsPerPage,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					done(err);
-					return;
-				}
-				newCurrentPage.should.equal('2');
-				before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
-				after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
-				pageCount.should.equal(4);
-				numPages.should.equal(2);
-				total.should.equal(14);
-				items.should.be.Array;
-				items.should.not.be.empty;
-				items[0].name.should.equal('MS Lync');
-				mongoose.Types.ObjectId.isValid(items[0]._id).should.be.truthy;
-				items[0]._id.should.deep.equal(mongoose.Types.ObjectId('54230d2c282a1115003542eb'));
-				_.size(items[0].toObject()).should.equal(2);
-				done();
-			},
 			{
 				columns: 'name'
 			}
-		);
+		)
+		.then(function(pagingData) {
+			pagingData.newCurrentPage.should.equal('2');
+			pagingData.before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
+			pagingData.after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
+			pagingData.pageCount.should.equal(4);
+			pagingData.numPages.should.equal(2);
+			pagingData.total.should.equal(14);
+			pagingData.items.should.be.Array;
+			pagingData.items.should.not.be.empty;
+			pagingData.items[0].name.should.equal('MS Lync');
+			mongoose.Types.ObjectId.isValid(pagingData.items[0]._id).should.be.truthy;
+			pagingData.items[0]._id.should.deep.equal(mongoose.Types.ObjectId('54230d2c282a1115003542eb'));
+			_.size(pagingData.items[0].toObject()).should.equal(2);
+		});
 	});
 
-	it('should return a filtered paginated collection upon providing options.after', function(done) {
+	it('should return a filtered paginated collection upon providing options.after', function() {
 		var currentPage = '1',
 			page = '2',
 			resultsPerPage = '10';
 
-		Course.paginate(
+		return Course.paginate(
 			{},
 			currentPage,
 			page,
 			resultsPerPage,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					done(err);
-					return;
-				}
-				newCurrentPage.should.equal('2');
-				before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
-				after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
-				pageCount.should.equal(4);
-				numPages.should.equal(2);
-				total.should.equal(14);
-				items.should.be.Array;
-				items.should.not.be.empty;
-				done();
-			},
 			{
 				after: {
 					_id: '54230b67282a1115003542d8'
 				}
 			}
-		);
+		)
+		.then(function(pagingData) {
+			pagingData.newCurrentPage.should.equal('2');
+			pagingData.before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
+			pagingData.after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
+			pagingData.pageCount.should.equal(4);
+			pagingData.numPages.should.equal(2);
+			pagingData.total.should.equal(14);
+			pagingData.items.should.be.Array;
+			pagingData.items.should.not.be.empty;
+		});
 	});
 
-	it('should return a filtered paginated collection upon providing options.before', function(done) {
+	it('should return a filtered paginated collection upon providing options.before', function() {
 		var currentPage = '2',
 			page = '1',
 			resultsPerPage = '10';
 
-		Course.paginate(
+		return Course.paginate(
 			{},
 			currentPage,
 			page,
 			resultsPerPage,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					done(err);
-					return;
-				}
-				newCurrentPage.should.equal('1');
-				before.should.equal('X2lkPTUzYmFiZmE1MTlhNGI0MDAwMGJjYjJkYQ%3D%3D');
-				after.should.equal('X2lkPTU0MjMwYjY3MjgyYTExMTUwMDM1NDJkOA%3D%3D');
-				pageCount.should.equal(10);
-				numPages.should.equal(2);
-				total.should.equal(14);
-				items.should.be.Array;
-				items.should.not.be.empty;
-				done();
-			},
 			{
 				before: {
 					_id: '54230d2c282a1115003542eb'
 				}
 			}
-		);
+		)
+		.then(function(pagingData) {
+			pagingData.newCurrentPage.should.equal('1');
+			pagingData.before.should.equal('X2lkPTUzYmFiZmE1MTlhNGI0MDAwMGJjYjJkYQ%3D%3D');
+			pagingData.after.should.equal('X2lkPTU0MjMwYjY3MjgyYTExMTUwMDM1NDJkOA%3D%3D');
+			pagingData.pageCount.should.equal(10);
+			pagingData.numPages.should.equal(2);
+			pagingData.total.should.equal(14);
+			pagingData.items.should.be.Array;
+			pagingData.items.should.not.be.empty;
+		});
 	});
 
-	it('should return the last page of a paginated collection upon providing options.last', function(done) {
+	it('should return the last page of a paginated collection upon providing options.last', function() {
 		var currentPage = '1',
 			page = '2',
 			resultsPerPage = '10';
 
-		Course.paginate(
+		return Course.paginate(
 			{},
 			currentPage,
 			page,
 			resultsPerPage,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					done(err);
-					return;
-				}
-				newCurrentPage.should.equal('2');
-				before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
-				after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
-				pageCount.should.equal(4);
-				numPages.should.equal(2);
-				total.should.equal(14);
-				items.should.be.Array;
-				items.should.not.be.empty;
-				done();
-			},
 			{
 				last: 'true'
 			}
-		);
+		)
+		.then(function(pagingData) {
+			pagingData.newCurrentPage.should.equal('2');
+			pagingData.before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
+			pagingData.after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
+			pagingData.pageCount.should.equal(4);
+			pagingData.numPages.should.equal(2);
+			pagingData.total.should.equal(14);
+			pagingData.items.should.be.Array;
+			pagingData.items.should.not.be.empty;
+		});
 	});
 
 	// not done
-	it('should return a paginated collection upon request', function(done) {
+	it('should return a paginated collection upon request', function() {
 		var currentPage = '1',
 			page = '2',
 			resultsPerPage = '10';
 
-		Course.paginate(
+		return Course.paginate(
 			{},
 			currentPage,
 			page,
 			resultsPerPage,
-			function(err, newCurrentPage, before, after, pageCount, numPages, total, items) {
-				if (err) {
-					done(err);
-					return;
-				}
-				newCurrentPage.should.equal('2');
-				before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
-				after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
-				pageCount.should.equal(4);
-				numPages.should.equal(2);
-				total.should.equal(14);
-				items.should.be.Array;
-				items.should.not.be.empty;
-				done();
-			},
 			{
 				populate: {path: 'facilitator', select: 'firstname lastname'}
 			}
-		);
+		)
+		.then(function(pagingData) {
+			pagingData.newCurrentPage.should.equal('2');
+			pagingData.before.should.equal('X2lkPTU0MjMwZDJjMjgyYTExMTUwMDM1NDJlYg%3D%3D');
+			pagingData.after.should.equal('X2lkPTU0MjMwZjE1MjgyYTExMTUwMDM1NDJmNQ%3D%3D');
+			pagingData.pageCount.should.equal(4);
+			pagingData.numPages.should.equal(2);
+			pagingData.total.should.equal(14);
+			pagingData.items.should.be.Array;
+			pagingData.items.should.not.be.empty;
+		});
 	});
 });

--- a/test/unit/paginationHelperSpec.js
+++ b/test/unit/paginationHelperSpec.js
@@ -1,7 +1,7 @@
 var should = require('chai').should(); // jshint ignore:line
 
-describe('expressPaginate', function () {
-	var expressPaginate = require('../../lib/expressPaginate');
+describe('paginationHelpers', function () {
+	var paginationHelpers = require('../../lib/paginationHelpers');
 
 	it('should set query parameters on call to setQueryParams', function(done) {
 		var req = {
@@ -12,7 +12,7 @@ describe('expressPaginate', function () {
 		},
 		defaultPageSize = 10,
 		maxPageSize = 50;
-		expressPaginate.setQueryParams(req, defaultPageSize, maxPageSize);
+		paginationHelpers.setQueryParams(req.query, defaultPageSize, maxPageSize);
 		req.query.should.not.be.empty;
 		req.query.page.should.equal(1);
 		req.query.currentPage.should.equal(req.query.page);
@@ -27,7 +27,7 @@ describe('expressPaginate', function () {
 				pageSize: 60
 			}
 		};
-		expressPaginate.setQueryParams(req, defaultPageSize, maxPageSize);
+		paginationHelpers.setQueryParams(req.query, defaultPageSize, maxPageSize);
 		req.query.should.deep.equal({
 			page: 1,
 			currentPage: 1,
@@ -39,7 +39,7 @@ describe('expressPaginate', function () {
 				pageSize: -1
 			}
 		};
-		expressPaginate.setQueryParams(req, null, null);
+		paginationHelpers.setQueryParams(req.query, null, null);
 		req.query.should.deep.equal({
 			currentPage: 1,
 			page: 1,
@@ -61,7 +61,7 @@ describe('expressPaginate', function () {
 			originalUrl: 'api/courses'
 		},
 		expectUrl = 'api/courses?sortBy=name&sortDirection=1&page=1&currentPage=5',
-		resultUrl = expressPaginate.firstPage(req);
+		resultUrl = paginationHelpers.firstPage(req, req.query);
 
 		resultUrl.should.equal(expectUrl);
 		done();
@@ -81,16 +81,16 @@ describe('expressPaginate', function () {
 		},
 		numPages = 10,
 		expectUrl = 'api/courses?before=X2lkPTU0MjQzMGZhYjZjOWIxMTUwMGNmZjdhZQ%253D%253D&sortBy=name&sortDirection=1&page=4&currentPage=5',
-		resultUrl = expressPaginate.prevPage(req, numPages);
+		resultUrl = paginationHelpers.prevPage(req, req.query, numPages);
 		resultUrl.should.equal(expectUrl);
 
 		numPages = 0,
-		resultUrl = expressPaginate.prevPage(req, numPages);
+		resultUrl = paginationHelpers.prevPage(req, req.query, numPages);
 		should.not.exist(resultUrl);
 
 		numPages = '0';
 		try {
-			expressPaginate.prevPage(req, numPages);
+			paginationHelpers.prevPage(req, req.query, numPages);
 		} catch (error) {
 			error.name.should.equal('InternalServerError');
 			error.status.should.equal(500);
@@ -114,16 +114,16 @@ describe('expressPaginate', function () {
 		},
 		numPages = 10,
 		expectUrl = 'api/courses?after=X2lkPTU1Nzg4MmQ4Njg0NDEyYWUyYzQyMjU2NA%253D%253D&sortBy=name&sortDirection=1&page=6&currentPage=5',
-		resultUrl = expressPaginate.nextPage(req, numPages);
+		resultUrl = paginationHelpers.nextPage(req, req.query, numPages);
 		resultUrl.should.equal(expectUrl);
 
 		numPages = 0,
-		resultUrl = expressPaginate.nextPage(req, numPages);
+		resultUrl = paginationHelpers.nextPage(req, req.query, numPages);
 		should.not.exist(resultUrl);
 
 		numPages = '0';
 		try {
-			expressPaginate.nextPage(req, numPages);
+			paginationHelpers.nextPage(req, req.query, numPages);
 		} catch (error) {
 			error.name.should.equal('InternalServerError');
 			error.status.should.equal(500);
@@ -147,7 +147,7 @@ describe('expressPaginate', function () {
 		},
 		numPages = 10,
 		expectUrl = 'api/courses?sortBy=name&sortDirection=1&page=10&currentPage=5&last=true',
-		resultUrl = expressPaginate.lastPage(req, numPages);
+		resultUrl = paginationHelpers.lastPage(req, req.query, numPages);
 
 		resultUrl.should.equal(expectUrl);
 		done();
@@ -166,7 +166,7 @@ describe('expressPaginate', function () {
 			originalUrl: 'api/courses'
 		},
 		expectUrl = 'api/courses?before=X2lkPTU0MjQzMGZhYjZjOWIxMTUwMGNmZjdhZQ%253D%253D&sortBy=date&sortDirection=1&page=5&currentPage=5',
-		resultUrl = expressPaginate.href(req)({sortBy: 'date'});
+		resultUrl = paginationHelpers.href(req)({sortBy: 'date'});
 
 		resultUrl.should.equal(expectUrl);
 		done();


### PR DESCRIPTION
Also updated mongoosePaginate plugin to use promises rather than a callback, which is a breaking change for all pre v1.0.0 uses of the plugin on a model directly (i.e. MongooseModel.paginate(...) )

@dougmoscrop please take a look.
